### PR TITLE
feat: Add notification and disconnect on elytra depletion

### DIFF
--- a/src/main/java/com/baseminer/basefinder/modules/BaseFinderModule.java
+++ b/src/main/java/com/baseminer/basefinder/modules/BaseFinderModule.java
@@ -14,7 +14,9 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.Chunk;
@@ -236,6 +238,29 @@ public class BaseFinderModule extends Module {
 
         if (mc.player == null || mc.world == null) {
             return;
+        }
+
+        // Elytra check
+        if (ElytraController.isActive() && mc.player.getEquippedStack(EquipmentSlot.CHEST).isEmpty()) {
+            // Send Discord notification
+            DiscordEmbed embed = new DiscordEmbed(
+                "Out of Elytras!",
+                "The bot has run out of elytras and will now disconnect.",
+                0xFF0000
+            );
+            DiscordWebhook.sendMessage("@everyone", embed);
+
+            // Disconnect from server
+            if (mc.getNetworkHandler() != null) {
+                mc.getNetworkHandler().getConnection().disconnect(Text.of("Ran out of elytras."));
+            }
+
+            // Stop elytra controller
+            ElytraController.stop();
+
+            // Deactivate the module
+            toggle();
+            return; // Stop further processing in onTick
         }
 
         // Death detection - check if player health dropped to 0 or respawned


### PR DESCRIPTION
This commit adds a feature to the BaseFinder module that checks if the bot has run out of elytras while the ElytraController is active.

When the bot's chest slot becomes empty, it now performs the following actions:
- Sends a Discord notification to inform the user that it has run out of elytras.
- Disconnects from the server with the message "Ran out of elytras."
- Stops the ElytraController and deactivates the BaseFinder module.

This prevents the bot from falling to its death and ensures the user is alerted to the situation.