### PR TITLE
feat: Add altitude loss detector and enhance unstuck feature

### DIFF
--- a/src/main/java/com/baseminer/basefinder/modules/AltitudeLossDetector.java
+++ b/src/main/java/com/baseminer/basefinder/modules/AltitudeLossDetector.java
@@ -1,0 +1,89 @@
+package com.baseminer.basefinder.modules;
+
+import com.baseminer.basefinder.BaseFinder;
+import com.baseminer.basefinder.utils.KeyHold;
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.option.KeyBinding;
+
+public class AltitudeLossDetector extends Module {
+    private final SettingGroup sgGeneral = this.settings.getDefaultGroup();
+
+    private final Setting<Integer> altitudeDropThreshold = sgGeneral.add(new IntSetting.Builder()
+        .name("altitude-drop-threshold")
+        .description("The number of blocks the player has to fall in one second to trigger the detector.")
+        .defaultValue(10)
+        .min(1)
+        .sliderMax(50)
+        .build()
+    );
+
+    private final Setting<Boolean> autoFix = sgGeneral.add(new BoolSetting.Builder()
+        .name("auto-fix")
+        .description("Automatically tries to fix the issue by holding spacebar.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private double lastYPosition;
+    private long lastCheckTime;
+    private boolean fixInProgress = false;
+    private int fixCooldown = 0;
+
+    public AltitudeLossDetector() {
+        super(BaseFinder.CATEGORY, "altitude-loss-detector", "Detects when you are rapidly losing altitude and tries to fix it.");
+    }
+
+    @Override
+    public void onActivate() {
+        lastYPosition = mc.player != null ? mc.player.getY() : 0;
+        lastCheckTime = System.currentTimeMillis();
+        fixInProgress = false;
+        fixCooldown = 0;
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Post event) {
+        if (mc.player == null || mc.world == null) {
+            return;
+        }
+
+        if (fixCooldown > 0) {
+            fixCooldown--;
+            return;
+        }
+
+        if (fixInProgress) {
+            return;
+        }
+
+        long currentTime = System.currentTimeMillis();
+        if (currentTime - lastCheckTime >= 1000) {
+            double currentYPosition = mc.player.getY();
+            double altitudeDrop = lastYPosition - currentYPosition;
+
+            if (altitudeDrop > altitudeDropThreshold.get()) {
+                handleStuck();
+            }
+
+            lastYPosition = currentYPosition;
+            lastCheckTime = currentTime;
+        }
+    }
+
+    private void handleStuck() {
+        info("Detected rapid altitude loss at " + mc.player.getBlockPos().toShortString());
+
+        if (autoFix.get()) {
+            fixInProgress = true;
+            info("Attempting to fix by holding jump...");
+            KeyHold.hold(mc.options.jumpKey, 5, (v) -> {
+                info("Jump complete.");
+                fixInProgress = false;
+                fixCooldown = 200;
+            });
+        }
+    }
+}

--- a/src/main/java/com/baseminer/basefinder/modules/StuckDetector.java
+++ b/src/main/java/com/baseminer/basefinder/modules/StuckDetector.java
@@ -4,12 +4,14 @@ import com.baseminer.basefinder.BaseFinder;
 import com.baseminer.basefinder.utils.Config;
 import com.baseminer.basefinder.utils.DiscordEmbed;
 import com.baseminer.basefinder.utils.DiscordWebhook;
+import com.baseminer.basefinder.utils.KeyHold;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.option.KeyBinding;
 import net.minecraft.item.Items;
 import net.minecraft.util.math.Vec3d;
 
@@ -141,19 +143,28 @@ public class StuckDetector extends Module {
                         if (mc.player.getPos().distanceTo(positionWhenStuck) < 1.0) {
                             info("Fix 1 seems to have failed. Attempting Fix 2: Stopping vanilla flight...");
                             mc.player.stopGliding();
+
+                            info("Attempting Fix 3: Holding jump...");
+                            KeyHold.hold(mc.options.jumpKey, 5, (v) -> {
+                                info("Jump complete.");
+                                fixInProgress = false;
+                                fixCooldown = 200;
+                            });
+
                         } else {
                             info("Fix 1 appears successful. No further action needed.");
+                            fixInProgress = false;
+                            fixCooldown = 200;
                         }
                     } else {
                         // ElytraFly not active, go straight to stopping flight
                         info("ElytraFly not active. Attempting to get unstuck by stopping flight...");
                         mc.player.stopGliding();
+                        fixInProgress = false;
+                        fixCooldown = 200;
                     }
                 } catch (InterruptedException e) {
                     e.printStackTrace();
-                } finally {
-                    fixInProgress = false;
-                    fixCooldown = 200; // Cooldown starts after all fix attempts
                 }
             }).start();
         }

--- a/src/main/java/com/baseminer/basefinder/utils/KeyHold.java
+++ b/src/main/java/com/baseminer/basefinder/utils/KeyHold.java
@@ -1,0 +1,49 @@
+package com.baseminer.basefinder.utils;
+
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.orbit.EventHandler;
+import meteordevelopment.orbit.EventBus;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.KeyBinding;
+
+import java.util.function.Consumer;
+
+public class KeyHold {
+    private static final MinecraftClient mc = MinecraftClient.getInstance();
+    private static KeyBinding key;
+    private static int durationTicks;
+    private static Consumer<Void> onComplete;
+    private static int ticksHeld;
+
+    public static void hold(KeyBinding keyToHold, int durationSeconds, Consumer<Void> onCompleteCallback) {
+        key = keyToHold;
+        durationTicks = durationSeconds * 20;
+        onComplete = onCompleteCallback;
+        ticksHeld = 0;
+
+        EventBus.subscribe(KeyHold.class);
+        KeyBinding.setKeyPressed(key.getDefaultKey(), true);
+    }
+
+    @EventHandler
+    private static void onTick(TickEvent.Post event) {
+        if (mc.player == null || mc.world == null) {
+            release();
+            return;
+        }
+
+        ticksHeld++;
+
+        if (ticksHeld >= durationTicks) {
+            release();
+        }
+    }
+
+    private static void release() {
+        KeyBinding.setKeyPressed(key.getDefaultKey(), false);
+        EventBus.unsubscribe(KeyHold.class);
+        if (onComplete != null) {
+            onComplete.accept(null);
+        }
+    }
+}


### PR DESCRIPTION
- Creates a new `AltitudeLossDetector` module to detect rapid altitude loss and trigger an auto-unstuck mechanism.
- The auto-unstuck feature simulates holding the jump key for 5 seconds to help the player recover from falls.
- Adds a new `KeyHold` utility class to manage key presses over a duration using tick events, ensuring stability and preventing race conditions.
- Enhances the existing `StuckDetector` module to also use the `KeyHold` utility, adding the 5-second jump to its arsenal of unstuck methods.